### PR TITLE
update example for v2 compatibility

### DIFF
--- a/BitioExample.java
+++ b/BitioExample.java
@@ -8,7 +8,7 @@ import java.util.Properties;
 public class BitioExample {
    public static void main(String args[]) {
       Connection c = null;
-      String bitApiKey = "<your_bitdotio_password>";
+      String bitApiKey = "<your_bitdotio_key>"; // "Password" from connect menu
       String bitDB = "dliden.2020_Census_Reapportionment";
       String bitUser = "<your_bitdotio_username>";
       String bitHost = "db.bit.io";

--- a/BitioExample.java
+++ b/BitioExample.java
@@ -8,9 +8,9 @@ import java.util.Properties;
 public class BitioExample {
    public static void main(String args[]) {
       Connection c = null;
-      String bitApiKey = "<your api key>";
-      String bitDB = "sensors";
-      String bitUser = "adam";
+      String bitApiKey = "<your_bitdotio_password>";
+      String bitDB = "dliden.2020_Census_Reapportionment";
+      String bitUser = "<your_bitdotio_username>";
       String bitHost = "db.bit.io";
       String bitPort = "5432"; // We keep this as a string here as we are concact'ing it into the connection string
       Properties props = new Properties();
@@ -22,7 +22,7 @@ public class BitioExample {
          c = DriverManager
             .getConnection("jdbc:postgresql://" + bitHost + ":" + bitPort + "/" + bitDB, props);
          Statement stmt = c.createStatement();
-         ResultSet rs = stmt.executeQuery("SELECT * FROM \"adam/sensors\".\"measurements\" order by datetime desc;" );
+         ResultSet rs = stmt.executeQuery("SELECT * FROM \"dliden/2020_Census_Reapportionment\".\"Historical Apportionment\" limit 10;" );
          while (rs.next()) {
              ResultSetMetaData rsmd = rs.getMetaData();
              // The ResultSet .getXXX() methods expect the column index to start at 1. 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # bitdotio-java-example
 An example of using Java &amp; JDBC with bit.io
 
+This example downloads a subset of a table from [this public database](https://bit.io/dliden/2020_Census_Reapportionment)
+
 First, download the latest version of the [Postgres JDBC](https://jdbc.postgresql.org/) driver, and
 put that jar file in this directory.
 
 Then, to run this code (replace the version of the postgres jar with the version you downloaded): 
 ```
 javac BitioExample.java
-java -cp .:postgresql-42.2.23.jar BitioExample
+java -cp .:postgresql-42.3.5.jar BitioExample
 ```
 


### PR DESCRIPTION
- Switched to a public db currently accessible on v2. Note that db name has to include `.` rather than `/` between username component and dbname component.
- bumped postgresql driver version # in example.